### PR TITLE
feat(lab): add phase 3 desktop toys

### DIFF
--- a/src/components/lab/LabShell.astro
+++ b/src/components/lab/LabShell.astro
@@ -1,0 +1,65 @@
+---
+type Props = {
+  astroVersion: string;
+  buildDate: string;
+  gitCommit: string;
+};
+
+const { astroVersion, buildDate, gitCommit } = Astro.props;
+---
+
+<section
+  class="lab-shell"
+  id="lab-shell"
+  data-astro-version={astroVersion}
+  data-build-date={buildDate}
+  data-git-commit={gitCommit}
+  role="dialog"
+  aria-modal="true"
+  aria-labelledby="lab-shell-title"
+  hidden
+>
+  <button type="button" class="lab-shell-backdrop" data-shell-close aria-label="Close command palette"></button>
+  <div class="lab-window lab-shell-window">
+    <div class="lab-titlebar">
+      <span class="lab-tb-title" id="lab-shell-title">pj@lab: ~</span>
+      <button type="button" class="lab-tb-x" data-shell-close aria-label="Close command palette">✕</button>
+    </div>
+    <div class="lab-shell-body">
+      <div class="lab-shell-output" data-shell-output aria-live="polite" aria-atomic="false">
+        <div class="lab-shell-line lab-shell-muted">PJ LAB SHELL 0.3.0 · type <span class="lab-shell-command">help</span></div>
+      </div>
+      <form class="lab-shell-form" data-shell-form>
+        <label class="lab-shell-prompt" for="lab-shell-input">pj@lab&nbsp;~&nbsp;$</label>
+        <input
+          class="lab-shell-input"
+          id="lab-shell-input"
+          data-shell-input
+          type="text"
+          inputmode="text"
+          autocomplete="off"
+          autocapitalize="none"
+          spellcheck="false"
+          aria-label="Lab command"
+        />
+        <span class="lab-shell-caret" aria-hidden="true">▮</span>
+      </form>
+    </div>
+  </div>
+</section>
+
+<div class="lab-rebuild" id="lab-rebuild" role="status" aria-live="assertive" hidden>
+  <div class="lab-rebuild-grid" aria-hidden="true"></div>
+  <div class="lab-rebuild-inner">
+    <div class="lab-rebuild-kicker">NIXOS REBUILD // LAB PROFILE</div>
+    <div class="lab-rebuild-theme" data-rebuild-theme>SAGE</div>
+    <div class="lab-rebuild-progress"><div data-rebuild-progress></div></div>
+    <div class="lab-rebuild-log" data-rebuild-log></div>
+  </div>
+</div>
+
+<div class="lab-konami" id="lab-konami" role="status" aria-live="assertive" hidden>
+  <div class="lab-konami-code">EMERGENCY</div>
+  <div class="lab-konami-title">PATTERN BLUE</div>
+  <div class="lab-konami-sub">ANGEL DETECTED // NERV OVERRIDE ACCEPTED</div>
+</div>

--- a/src/components/lab/LabWaybar.astro
+++ b/src/components/lab/LabWaybar.astro
@@ -25,6 +25,16 @@ const workspaces = [
     ))}
   </div>
   <div class="lab-wb-right">
+    <button
+      type="button"
+      class="lab-shell-launcher"
+      data-shell-open
+      aria-label="Open lab command palette"
+      aria-controls="lab-shell"
+      aria-haspopup="dialog"
+      aria-keyshortcuts="Space"
+      title="[space] command palette"
+    >&gt;_</button>
     <span class="lab-dot"></span> 5 NODES&nbsp;&nbsp;&nbsp;ZFS 58%&nbsp;&nbsp;&nbsp;<span id="lab-clock">--:--</span>
     <a href="/" class="lab-wb-exit">EXIT →</a>
   </div>

--- a/src/pages/lab/index.astro
+++ b/src/pages/lab/index.astro
@@ -2,6 +2,7 @@
 // Standalone page: /lab is the one route that becomes a full-viewport dark
 // desktop, so it does NOT use the site Layout (no header/footer).
 import { getCollection } from 'astro:content';
+import { execFileSync } from 'node:child_process';
 import '../../styles/global.css';
 import '../../styles/lab.css';
 import LabWaybar from '../../components/lab/LabWaybar.astro';
@@ -10,9 +11,33 @@ import LabNetwork from '../../components/lab/LabNetwork.astro';
 import LabCompute from '../../components/lab/LabCompute.astro';
 import LabStorage from '../../components/lab/LabStorage.astro';
 import LabLog from '../../components/lab/LabLog.astro';
+import LabShell from '../../components/lab/LabShell.astro';
 
 const allPosts = await getCollection('lab', ({ data }) => !data.draft);
 const noscriptPosts = allPosts.sort((a, b) => b.data.date.getTime() - a.data.date.getTime());
+const astroVersion = Astro.generator.replace(/^Astro\s+v?/i, '');
+const buildDate = new Date().toISOString().slice(0, 10);
+
+function resolveGitCommit() {
+  const suppliedCommit = [
+    process.env.SOURCE_COMMIT,
+    process.env.COOLIFY_GIT_COMMIT_SHA,
+    process.env.GITHUB_SHA,
+    process.env.COMMIT_SHA,
+  ].find(Boolean);
+  if (suppliedCommit) return suppliedCommit.slice(0, 7);
+
+  try {
+    return execFileSync('git', ['rev-parse', '--short', 'HEAD'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    return 'unknown';
+  }
+}
+
+const gitCommit = resolveGitCommit();
 ---
 
 <!doctype html>
@@ -85,7 +110,7 @@ const noscriptPosts = allPosts.sort((a, b) => b.data.date.getTime() - a.data.dat
       </div>
     </noscript>
 
-    <div class="lab-desktop" id="lab-desktop">
+    <div class="lab-desktop" id="lab-desktop" data-lab-theme="sage">
       <LabBoot />
       <LabWaybar />
       <div class="lab-scenes">
@@ -94,10 +119,12 @@ const noscriptPosts = allPosts.sort((a, b) => b.data.date.getTime() - a.data.dat
         <LabStorage />
         <LabLog />
       </div>
+      <LabShell astroVersion={astroVersion} buildDate={buildDate} gitCommit={gitCommit} />
     </div>
 
     <script>
       import { initLabWindowManager } from '../../scripts/labWindowManager';
+      import { initLabShell } from '../../scripts/labShell';
 
       const bootEl = document.getElementById('lab-boot') as HTMLElement | null;
       const bootBarFill = document.getElementById('lab-boot-bar-fill') as HTMLElement | null;
@@ -164,6 +191,7 @@ const noscriptPosts = allPosts.sort((a, b) => b.data.date.getTime() - a.data.dat
       });
 
       initLabWindowManager(prefersReducedMotion);
+      initLabShell(prefersReducedMotion);
 
       // ---------- Live clock ----------
 

--- a/src/scripts/labShell.ts
+++ b/src/scripts/labShell.ts
@@ -1,0 +1,318 @@
+import { gsap } from 'gsap';
+
+const THEMES = ['sage', 'gruvbox', 'tokyo-night', 'nerv'] as const;
+type LabTheme = (typeof THEMES)[number];
+
+const THEME_LABELS: Record<LabTheme, string> = {
+  sage: 'SAGE',
+  gruvbox: 'GRUVBOX',
+  'tokyo-night': 'TOKYO NIGHT',
+  nerv: 'NERV',
+};
+
+const KONAMI = ['arrowup', 'arrowup', 'arrowdown', 'arrowdown', 'arrowleft', 'arrowright', 'arrowleft', 'arrowright', 'b', 'a'];
+
+type ShellMetadata = {
+  astroVersion: string;
+  buildDate: string;
+  gitCommit: string;
+};
+
+type OutputTone = 'normal' | 'muted' | 'success' | 'warn' | 'error';
+
+export function initLabShell(reducedMotion: boolean) {
+  const desktop = document.getElementById('lab-desktop');
+  const shell = document.getElementById('lab-shell');
+  const input = shell?.querySelector<HTMLInputElement>('[data-shell-input]');
+  const form = shell?.querySelector<HTMLFormElement>('[data-shell-form]');
+  const output = shell?.querySelector<HTMLElement>('[data-shell-output]');
+  const rebuild = document.getElementById('lab-rebuild');
+  const rebuildTheme = rebuild?.querySelector<HTMLElement>('[data-rebuild-theme]');
+  const rebuildProgress = rebuild?.querySelector<HTMLElement>('[data-rebuild-progress]');
+  const rebuildLog = rebuild?.querySelector<HTMLElement>('[data-rebuild-log]');
+  const konamiAlert = document.getElementById('lab-konami');
+
+  if (!desktop || !shell || !input || !form || !output || !rebuild || !rebuildTheme || !rebuildProgress || !rebuildLog || !konamiAlert) return;
+
+  const root: HTMLElement = desktop;
+  const shellRoot: HTMLElement = shell;
+  const shellInput: HTMLInputElement = input;
+  const shellOutput: HTMLElement = output;
+  const rebuildRoot: HTMLElement = rebuild;
+  const rebuildThemeEl: HTMLElement = rebuildTheme;
+  const rebuildProgressEl: HTMLElement = rebuildProgress;
+  const rebuildLogEl: HTMLElement = rebuildLog;
+  const konamiRoot: HTMLElement = konamiAlert;
+  const metadata: ShellMetadata = {
+    astroVersion: shellRoot.dataset.astroVersion ?? 'unknown',
+    buildDate: shellRoot.dataset.buildDate ?? 'unknown',
+    gitCommit: shellRoot.dataset.gitCommit ?? 'unknown',
+  };
+
+  let activeTheme: LabTheme = 'sage';
+  let lastFocused: HTMLElement | null = null;
+  let rebuilding = false;
+  let historyIndex = 0;
+  const history: string[] = [];
+  const konamiBuffer: string[] = [];
+
+  function appendLine(text: string, tone: OutputTone = 'normal') {
+    const line = document.createElement('div');
+    line.className = `lab-shell-line lab-shell-${tone}`;
+    line.textContent = text;
+    shellOutput.appendChild(line);
+    shellOutput.scrollTop = shellOutput.scrollHeight;
+  }
+
+  function appendBlock(text: string, tone: OutputTone = 'normal') {
+    const block = document.createElement('pre');
+    block.className = `lab-shell-block lab-shell-${tone}`;
+    block.textContent = text;
+    shellOutput.appendChild(block);
+    shellOutput.scrollTop = shellOutput.scrollHeight;
+  }
+
+  function echoCommand(command: string) {
+    const line = document.createElement('div');
+    line.className = 'lab-shell-line lab-shell-echo';
+    const prompt = document.createElement('span');
+    prompt.className = 'lab-shell-prompt-inline';
+    prompt.textContent = 'pj@lab ~ $ ';
+    line.append(prompt, document.createTextNode(command));
+    shellOutput.appendChild(line);
+  }
+
+  function setTheme(theme: LabTheme) {
+    activeTheme = theme;
+    root.dataset.labTheme = theme;
+  }
+
+  function nextTheme() {
+    const index = THEMES.indexOf(activeTheme);
+    return THEMES[(index + 1) % THEMES.length];
+  }
+
+  function parseThemeArgument(raw: string): LabTheme | null {
+    let value = raw.trim().toLowerCase();
+    if (!value) return nextTheme();
+    value = value.replace(/^--flake\s+/, '').replace(/^\.\//, '').replace(/^\.?#/, '');
+    value = value.replace(/^--theme(?:=|\s+)/, '');
+    if (value === 'tokyo' || value === 'tokyonight') value = 'tokyo-night';
+    return THEMES.includes(value as LabTheme) ? value as LabTheme : null;
+  }
+
+  function renderHelp() {
+    appendBlock([
+      'AVAILABLE COMMANDS',
+      '  help                                  show this list',
+      '  fastfetch | neofetch                  identify this machine',
+      '  sudo rm -rf /                         absolutely do not',
+      '  sudo pacman -S personality            install missing personality',
+      '  nixos-rebuild switch [theme]           rebuild; no theme cycles',
+      '  nixos-rebuild switch --flake .#nerv   target a lab profile',
+      '  clear                                 clear the terminal',
+      '',
+      'THEMES  sage · gruvbox · tokyo-night · nerv',
+      'HOTKEYS SPACE open · ESC close · ↑/↓ history',
+    ].join('\n'), 'muted');
+  }
+
+  function renderFastfetch() {
+    appendBlock([
+      '       ___       PJ@LAB',
+      '   ___/ _ \\___   ─────────────────────────',
+      '  / _  /_/ / _ \\  OS      PJ Lab Desktop',
+      '  \\_,_/ .__/\___/  HOST    pachevjoseph.com',
+      '     /_/          STACK   Astro + TypeScript + GSAP',
+      `                  ASTRO   ${metadata.astroVersion}`,
+      `                  BUILT   ${metadata.buildDate}`,
+      `                  COMMIT  ${metadata.gitCommit}`,
+      `                  THEME   ${THEME_LABELS[activeTheme]}`,
+      '                  WM      suspiciously functional',
+    ].join('\n'), 'success');
+  }
+
+  function finishRebuild(theme: LabTheme) {
+    rebuildRoot.hidden = true;
+    rebuilding = false;
+    gsap.set(rebuildRoot, { clearProps: 'opacity,filter' });
+    gsap.set(rebuildProgressEl, { clearProps: 'width' });
+    appendLine(`switching to configuration ${THEME_LABELS[theme]}... done`, 'success');
+    appendLine('warning: 0 packages changed, 100% more personality detected', 'warn');
+  }
+
+  function runRebuild(theme: LabTheme) {
+    if (rebuilding) {
+      appendLine('error: a rebuild is already doing something dramatic', 'error');
+      return;
+    }
+
+    rebuilding = true;
+    rebuildThemeEl.textContent = THEME_LABELS[theme];
+    rebuildLogEl.textContent = 'evaluating flake...';
+    rebuildRoot.hidden = false;
+    gsap.set(rebuildProgressEl, { width: '0%' });
+
+    if (reducedMotion) {
+      setTheme(theme);
+      rebuildLogEl.textContent = 'configuration switched (cinematics disabled)';
+      finishRebuild(theme);
+      return;
+    }
+
+    const timeline = gsap.timeline({ onComplete: () => finishRebuild(theme) });
+    timeline
+      .fromTo(rebuildRoot, { opacity: 0 }, { opacity: 1, duration: 0.12, ease: 'none' })
+      .to(rebuildProgressEl, { width: '18%', duration: 0.2, ease: 'steps(3)' })
+      .call(() => { rebuildLogEl.textContent = 'building /nix/store/pj-lab-personality.drv...'; })
+      .to(rebuildProgressEl, { width: '46%', duration: 0.28, ease: 'steps(5)' })
+      .call(() => { rebuildLogEl.textContent = 'stopping graphical-session.target... probably fine'; })
+      .to(root, { x: -8, duration: 0.05, yoyo: true, repeat: 5, ease: 'none' })
+      .to(rebuildProgressEl, { width: '73%', duration: 0.3, ease: 'steps(4)' }, '<')
+      .call(() => {
+        setTheme(theme);
+        rebuildLogEl.textContent = `activating ${THEME_LABELS[theme]} specialisation...`;
+      })
+      .to(rebuildRoot, { filter: 'brightness(2.8) contrast(1.4)', duration: 0.08, yoyo: true, repeat: 3 })
+      .to(rebuildProgressEl, { width: '100%', duration: 0.36, ease: 'power2.out' })
+      .call(() => { rebuildLogEl.textContent = 'restarting vibes.service... done'; })
+      .to(rebuildRoot, { opacity: 0, duration: 0.24, delay: 0.32, ease: 'power2.in' });
+  }
+
+  function execute(command: string) {
+    const normalized = command.trim().replace(/\s+/g, ' ');
+    if (!normalized) return;
+    echoCommand(normalized);
+
+    if (normalized === 'help') {
+      renderHelp();
+      return;
+    }
+    if (normalized === 'clear') {
+      shellOutput.replaceChildren();
+      return;
+    }
+    if (normalized === 'fastfetch' || normalized === 'neofetch') {
+      renderFastfetch();
+      return;
+    }
+    if (/^sudo rm -rf \/(?: --no-preserve-root)?$/.test(normalized)) {
+      appendLine('nice try.', 'error');
+      return;
+    }
+    if (normalized === 'sudo pacman -S personality') {
+      appendLine('error: target not found: personality', 'error');
+      appendLine('hint: already installed', 'success');
+      return;
+    }
+
+    const rebuildPrefix = 'nixos-rebuild switch';
+    if (normalized === rebuildPrefix || normalized.startsWith(`${rebuildPrefix} `)) {
+      const theme = parseThemeArgument(normalized.slice(rebuildPrefix.length));
+      if (!theme) {
+        appendLine('error: unknown lab profile', 'error');
+        appendLine(`available: ${THEMES.join(' · ')}`, 'muted');
+        return;
+      }
+      runRebuild(theme);
+      return;
+    }
+
+    appendLine(`command not found: ${normalized.split(' ')[0]}`, 'error');
+    appendLine('type help before you hurt yourself', 'muted');
+  }
+
+  function openShell() {
+    if (!shellRoot.hidden) return;
+    lastFocused = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    shellRoot.hidden = false;
+    if (!reducedMotion) {
+      gsap.fromTo(shellRoot.querySelector('.lab-shell-window'), { opacity: 0, y: -18, scale: 0.97 }, { opacity: 1, y: 0, scale: 1, duration: 0.22, ease: 'back.out(1.5)', clearProps: 'opacity,transform' });
+    }
+    requestAnimationFrame(() => shellInput.focus());
+  }
+
+  function closeShell() {
+    if (shellRoot.hidden) return;
+    const finish = () => {
+      shellRoot.hidden = true;
+      shellInput.value = '';
+      lastFocused?.focus();
+    };
+    if (reducedMotion) {
+      finish();
+      return;
+    }
+    gsap.to(shellRoot.querySelector('.lab-shell-window'), { opacity: 0, y: -10, scale: 0.98, duration: 0.13, ease: 'power2.in', onComplete: finish });
+  }
+
+  function triggerKonami() {
+    setTheme('nerv');
+    konamiRoot.hidden = false;
+
+    if (reducedMotion) {
+      window.setTimeout(() => { konamiRoot.hidden = true; }, 1500);
+      return;
+    }
+
+    gsap.timeline({ onComplete: () => { konamiRoot.hidden = true; } })
+      .fromTo(konamiRoot, { opacity: 0 }, { opacity: 1, duration: 0.08 })
+      .fromTo(root, { x: -6 }, { x: 6, duration: 0.04, repeat: 9, yoyo: true, ease: 'none' }, '<')
+      .to(konamiRoot, { opacity: 0, duration: 0.22, delay: 1.5 });
+  }
+
+  form.addEventListener('submit', (event) => {
+    event.preventDefault();
+    const command = shellInput.value;
+    if (command.trim()) {
+      history.push(command);
+      historyIndex = history.length;
+    }
+    shellInput.value = '';
+    execute(command);
+  });
+
+  shellInput.addEventListener('keydown', (event) => {
+    if (event.key === 'ArrowUp' && history.length) {
+      event.preventDefault();
+      historyIndex = Math.max(0, historyIndex - 1);
+      shellInput.value = history[historyIndex] ?? '';
+    } else if (event.key === 'ArrowDown' && history.length) {
+      event.preventDefault();
+      historyIndex = Math.min(history.length, historyIndex + 1);
+      shellInput.value = history[historyIndex] ?? '';
+    }
+  });
+
+  shellRoot.querySelectorAll<HTMLElement>('[data-shell-close]').forEach((button) => {
+    button.addEventListener('click', closeShell);
+  });
+  root.querySelector<HTMLElement>('[data-shell-open]')?.addEventListener('click', openShell);
+
+  document.addEventListener('keydown', (event) => {
+    const target = event.target as HTMLElement | null;
+    const editable = target?.matches('input, textarea, select, [contenteditable="true"]') ?? false;
+
+    if (event.key === 'Escape' && !shellRoot.hidden) {
+      event.preventDefault();
+      closeShell();
+      return;
+    }
+
+    if (event.code === 'Space' && shellRoot.hidden && !editable) {
+      const boot = document.getElementById('lab-boot');
+      if (boot && !boot.hidden) return;
+      event.preventDefault();
+      openShell();
+    }
+
+    if (!editable) {
+      konamiBuffer.push(event.key.toLowerCase());
+      if (konamiBuffer.length > KONAMI.length) konamiBuffer.shift();
+      if (konamiBuffer.length === KONAMI.length && konamiBuffer.every((key, index) => key === KONAMI[index])) {
+        konamiBuffer.length = 0;
+        triggerKonami();
+      }
+    }
+  });
+}

--- a/src/styles/lab.css
+++ b/src/styles/lab.css
@@ -16,13 +16,91 @@
   --lab-warn: #d4b483;
   --lab-err: #c98a7d;
   --lab-boot-bg: #0d0f0c;
+  --lab-wallpaper:
+    linear-gradient(rgba(163, 179, 160, 0.025) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(163, 179, 160, 0.025) 1px, transparent 1px),
+    radial-gradient(circle at 74% 18%, rgba(130, 146, 128, 0.09), transparent 36%);
+  --lab-wallpaper-size: 42px 42px, 42px 42px, auto;
 
   position: fixed;
   inset: 0;
-  background: var(--lab-bg);
+  background-color: var(--lab-bg);
+  background-image: var(--lab-wallpaper);
+  background-size: var(--lab-wallpaper-size);
   color: var(--lab-text);
   font-family: 'JetBrainsMono Nerd Font', 'JetBrains Mono', ui-monospace, monospace;
   overflow: hidden;
+}
+
+.lab-desktop[data-lab-theme='gruvbox'] {
+  --lab-bg: #1d2021;
+  --lab-surface: #282828;
+  --lab-raised: #32302f;
+  --lab-border: #3c3836;
+  --lab-border-bright: #665c54;
+  --lab-text: #d5c4a1;
+  --lab-bright: #fbf1c7;
+  --lab-muted: #928374;
+  --lab-dim: #665c54;
+  --lab-sage: #b8bb26;
+  --lab-accent: #d79921;
+  --lab-warn: #fe8019;
+  --lab-err: #fb4934;
+  --lab-boot-bg: #1b1b1b;
+  --lab-wallpaper:
+    repeating-linear-gradient(135deg, rgba(215, 153, 33, 0.035) 0 1px, transparent 1px 18px),
+    radial-gradient(circle at 18% 76%, rgba(184, 187, 38, 0.1), transparent 34%);
+  --lab-wallpaper-size: auto;
+}
+
+.lab-desktop[data-lab-theme='tokyo-night'] {
+  --lab-bg: #16161e;
+  --lab-surface: #1a1b26;
+  --lab-raised: #24283b;
+  --lab-border: #292e42;
+  --lab-border-bright: #3b4261;
+  --lab-text: #a9b1d6;
+  --lab-bright: #c0caf5;
+  --lab-muted: #565f89;
+  --lab-dim: #414868;
+  --lab-sage: #7aa2f7;
+  --lab-accent: #bb9af7;
+  --lab-warn: #e0af68;
+  --lab-err: #f7768e;
+  --lab-boot-bg: #101014;
+  --lab-wallpaper:
+    linear-gradient(120deg, transparent 42%, rgba(187, 154, 247, 0.045) 42% 43%, transparent 43%),
+    radial-gradient(ellipse at 78% 25%, rgba(122, 162, 247, 0.13), transparent 38%),
+    radial-gradient(ellipse at 12% 92%, rgba(187, 154, 247, 0.08), transparent 36%);
+  --lab-wallpaper-size: 90px 90px, auto, auto;
+}
+
+.lab-desktop[data-lab-theme='nerv'] {
+  --lab-bg: #090807;
+  --lab-surface: #15120f;
+  --lab-raised: #211913;
+  --lab-border: #443026;
+  --lab-border-bright: #76402d;
+  --lab-text: #d6c6b8;
+  --lab-bright: #fff4e6;
+  --lab-muted: #8f7669;
+  --lab-dim: #5c443a;
+  --lab-sage: #ff6b35;
+  --lab-accent: #ef2d56;
+  --lab-warn: #ffc857;
+  --lab-err: #ff2e2e;
+  --lab-boot-bg: #050403;
+  --lab-wallpaper:
+    linear-gradient(115deg, transparent 0 68%, rgba(239, 45, 86, 0.075) 68% 69%, transparent 69%),
+    repeating-linear-gradient(0deg, rgba(255, 107, 53, 0.025) 0 1px, transparent 1px 5px),
+    radial-gradient(circle at 78% 64%, rgba(239, 45, 86, 0.14), transparent 28%);
+  --lab-wallpaper-size: 120px 120px, auto, auto;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .lab-desktop {
+    transition: background-color 0.32s ease, color 0.24s ease;
+  }
 }
 
 .lab-desktop * {
@@ -91,6 +169,24 @@
   align-items: center;
   gap: 8px;
   white-space: nowrap;
+}
+
+.lab-shell-launcher {
+  border: 1px solid var(--lab-border);
+  background: transparent;
+  color: var(--lab-sage);
+  font: inherit;
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  padding: 4px 7px;
+  cursor: pointer;
+}
+
+.lab-shell-launcher:hover,
+.lab-shell-launcher:focus-visible {
+  border-color: var(--lab-sage);
+  color: var(--lab-bright);
+  outline: none;
 }
 
 .lab-dot {
@@ -332,4 +428,259 @@
 .lab-wb-exit:hover {
   color: var(--lab-bright);
   box-shadow: inset 0 -2px 0 var(--lab-sage);
+}
+
+/* ---------- Phase 3 shell / theme theater ---------- */
+
+.lab-shell {
+  position: fixed;
+  inset: 0;
+  z-index: 80;
+  display: grid;
+  place-items: start center;
+  padding-top: clamp(72px, 12vh, 132px);
+}
+
+.lab-shell[hidden],
+.lab-rebuild[hidden],
+.lab-konami[hidden] {
+  display: none;
+}
+
+.lab-shell-backdrop {
+  position: absolute;
+  inset: 0;
+  border: 0;
+  background: rgba(4, 5, 4, 0.74);
+  cursor: default;
+}
+
+.lab-shell-window {
+  position: relative;
+  width: min(760px, calc(100vw - 32px));
+  height: min(510px, calc(100vh - 160px));
+  min-height: 320px;
+  display: flex;
+  flex-direction: column;
+  border-color: var(--lab-sage);
+  box-shadow: 14px 14px 0 rgba(0, 0, 0, 0.58);
+}
+
+.lab-shell-body {
+  min-height: 0;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  padding: 18px 20px;
+  background:
+    linear-gradient(rgba(163, 179, 160, 0.018) 1px, transparent 1px),
+    var(--lab-surface);
+  background-size: 100% 4px, auto;
+}
+
+.lab-shell-output {
+  min-height: 0;
+  flex: 1;
+  overflow: auto;
+  padding-bottom: 14px;
+  scrollbar-color: var(--lab-border-bright) transparent;
+}
+
+.lab-shell-line,
+.lab-shell-block {
+  margin: 0 0 8px;
+  color: var(--lab-text);
+  font: inherit;
+  font-size: 12px;
+  line-height: 1.6;
+  white-space: pre-wrap;
+}
+
+.lab-shell-echo {
+  color: var(--lab-bright);
+  margin-top: 12px;
+}
+
+.lab-shell-prompt-inline,
+.lab-shell-command,
+.lab-shell-success {
+  color: var(--lab-sage);
+}
+
+.lab-shell-muted {
+  color: var(--lab-muted);
+}
+
+.lab-shell-warn {
+  color: var(--lab-warn);
+}
+
+.lab-shell-error {
+  color: var(--lab-err);
+}
+
+.lab-shell-form {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  border-top: 1px solid var(--lab-border);
+  padding-top: 14px;
+}
+
+.lab-shell-prompt {
+  color: var(--lab-sage);
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+.lab-shell-input {
+  min-width: 0;
+  flex: 1;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: var(--lab-bright);
+  caret-color: transparent;
+  font: inherit;
+  font-size: 12px;
+}
+
+.lab-shell-caret {
+  color: var(--lab-sage);
+  font-size: 12px;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .lab-shell-caret {
+    animation: lab-blink 1.1s steps(1) infinite;
+  }
+}
+
+.lab-rebuild {
+  position: fixed;
+  inset: 0;
+  z-index: 120;
+  overflow: hidden;
+  display: grid;
+  place-items: center;
+  background: var(--lab-boot-bg);
+  color: var(--lab-bright);
+}
+
+.lab-rebuild-grid {
+  position: absolute;
+  inset: -30%;
+  background:
+    linear-gradient(var(--lab-border) 1px, transparent 1px),
+    linear-gradient(90deg, var(--lab-border) 1px, transparent 1px);
+  background-size: 46px 46px;
+  transform: perspective(420px) rotateX(62deg) translateY(24%);
+  opacity: 0.36;
+}
+
+.lab-rebuild-inner {
+  position: relative;
+  width: min(680px, calc(100vw - 40px));
+  border-left: 8px solid var(--lab-sage);
+  padding: 24px 28px;
+  background: color-mix(in srgb, var(--lab-surface) 92%, transparent);
+  box-shadow: 16px 16px 0 rgba(0, 0, 0, 0.55);
+}
+
+.lab-rebuild-kicker {
+  color: var(--lab-muted);
+  font-size: 10px;
+  letter-spacing: 0.24em;
+}
+
+.lab-rebuild-theme {
+  margin: 18px 0 24px;
+  color: var(--lab-bright);
+  font-size: clamp(38px, 9vw, 88px);
+  font-weight: 700;
+  letter-spacing: -0.06em;
+  line-height: 0.9;
+}
+
+.lab-rebuild-progress {
+  height: 18px;
+  padding: 3px;
+  border: 1px solid var(--lab-border-bright);
+}
+
+.lab-rebuild-progress > div {
+  width: 0;
+  height: 100%;
+  background: repeating-linear-gradient(90deg, var(--lab-sage) 0 15px, transparent 15px 19px);
+}
+
+.lab-rebuild-log {
+  min-height: 18px;
+  margin-top: 14px;
+  color: var(--lab-accent);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+}
+
+.lab-konami {
+  position: fixed;
+  inset: 0;
+  z-index: 130;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  pointer-events: none;
+  background:
+    repeating-linear-gradient(0deg, rgba(255, 46, 46, 0.08) 0 2px, transparent 2px 6px),
+    rgba(8, 0, 0, 0.9);
+  border: clamp(8px, 2vw, 24px) solid var(--lab-err);
+}
+
+.lab-konami-code {
+  color: var(--lab-warn);
+  font-size: 11px;
+  letter-spacing: 0.42em;
+}
+
+.lab-konami-title {
+  color: var(--lab-err);
+  font-size: clamp(48px, 12vw, 128px);
+  font-weight: 700;
+  letter-spacing: -0.08em;
+  line-height: 1;
+  text-shadow: 7px 7px 0 rgba(255, 107, 53, 0.18);
+}
+
+.lab-konami-sub {
+  margin-top: 20px;
+  color: var(--lab-bright);
+  font-size: 11px;
+  letter-spacing: 0.18em;
+}
+
+@media (max-width: 900px) {
+  .lab-shell {
+    padding-top: 92px;
+  }
+
+  .lab-shell-window {
+    height: calc(100vh - 116px);
+  }
+
+  .lab-shell-body {
+    padding: 14px;
+  }
+
+  .lab-shell-line,
+  .lab-shell-block,
+  .lab-shell-input,
+  .lab-shell-prompt {
+    font-size: 11px;
+  }
+
+  .lab-rebuild-inner {
+    padding: 20px;
+  }
 }


### PR DESCRIPTION
## Summary

- add a Space-triggered fake shell plus a touch-friendly waybar launcher, command history, help, fastfetch build metadata, and the requested joke commands
- add SAGE, GRUVBOX, TOKYO NIGHT, and NERV token/wallpaper profiles scoped entirely to the lab route
- run theme changes through a GSAP-backed `nixos-rebuild switch` sequence, with an instant reduced-motion path
- turn the Konami code into a NERV `PATTERN BLUE` emergency override

## Shell commands

- `help`
- `fastfetch` / `neofetch`
- `sudo rm -rf /`
- `sudo pacman -S personality`
- `nixos-rebuild switch [theme]`
- `nixos-rebuild switch --flake .#nerv`
- `clear`

## Verification

- `ASTRO_TELEMETRY_DISABLED=1 node_modules/.bin/tsc --noEmit`
- `ASTRO_TELEMETRY_DISABLED=1 node_modules/.bin/astro build`
- DOM smoke checks for keyboard/touch opening, all commands, build metadata, targeted/cycling themes, Konami, Escape, and reduced-motion behavior
- full-motion smoke check for the animated rebuild lifecycle

The production build still reports the existing warnings for the empty `lab` and `essays` collections, then completes successfully.

Closes #5
Refs #3